### PR TITLE
fix: respect options.cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ module.exports = function (src, dest, opts, cb) {
 
 	cb = cb || function () {};
 
+	var cwd = opts.cwd || '';
+
 	globby(src, opts, function (err, files) {
 		if (err) {
 			cb(err);
@@ -23,7 +25,7 @@ module.exports = function (src, dest, opts, cb) {
 		}
 
 		eachAsync(files, function (el, i, next) {
-			cpFile(el, path.join(dest, el), opts, next);
+			cpFile(path.join(cwd, el), path.join(dest, el), opts, next);
 		}, cb);
 	});
 };

--- a/test.js
+++ b/test.js
@@ -4,11 +4,24 @@ var fs = require('fs');
 var cpy = require('./');
 
 afterEach(function () {
-	try {
-		fs.unlinkSync('tmp/license');
-		fs.unlinkSync('tmp/package.json');
-	} catch (err) {}
-	fs.rmdirSync('tmp');
+	[
+		'tmp/license',
+		'tmp/package.json',
+		'tmp/cwd/hello.js',
+		'tmp/hello.js'
+	].forEach(function(path) {
+		try {
+			fs.unlinkSync(path);
+		} catch (err) {}
+	});
+	[
+		'tmp/cwd',
+		'tmp'
+	].forEach(function(path) {
+		try {
+			fs.rmdirSync(path);
+		} catch (err) {}
+	});
 });
 
 it('should copy files', function (cb) {
@@ -23,6 +36,23 @@ it('should copy files', function (cb) {
 		assert.strictEqual(
 			fs.readFileSync('package.json', 'utf8'),
 			fs.readFileSync('tmp/package.json', 'utf8')
+		);
+
+		cb();
+	});
+});
+
+it('should respect cwd', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.mkdirSync('tmp/cwd');
+	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+	cpy(['hello.js'], 'tmp', {cwd: 'tmp/cwd'}, function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+			fs.readFileSync('tmp/hello.js', 'utf8')
 		);
 
 		cb();


### PR DESCRIPTION
First, thank you for this module. :+1:

Please consider the following directory structure:

```
src/
    a.js
    ...
dest/
```

One may try to copy all `*.js` below `src` to `dest`:

```
src/
    a.js
    ...
dest/
    a.js
    ...
```

but currently using

```
cpy(['*.js'], 'dest', {cwd: 'src'}, cb);
```

throws an ENOENT-Error because `a.js` cannot be found within the `process.cwd` directory.
This PR fixes that issue.
