### PR TITLE
Don't create paths when copying files

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = function (src, dest, opts, cb) {
 		}
 
 		eachAsync(files, function (el, i, next) {
-			cpFile(path.join(cwd, el), path.join(dest, el), opts, next);
+			var file = opts.parents ? el : path.basename(el);
+			cpFile(path.join(cwd, el), path.join(dest, file), opts, next);
 		}, cb);
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,13 @@ Default: `process.cwd()`
 
 The working directory to look for the source files.
 
+##### parents
+
+Type: `boolean`  
+Default: `false`
+
+Keep the path structure when copying files.
+
 
 #### callback(err)
 

--- a/test.js
+++ b/test.js
@@ -8,16 +8,19 @@ afterEach(function () {
 		'tmp/license',
 		'tmp/package.json',
 		'tmp/cwd/hello.js',
-		'tmp/hello.js'
-	].forEach(function(path) {
+		'tmp/hello.js',
+		'tmp/tmp/cwd/hello.js'
+	].forEach(function (path) {
 		try {
 			fs.unlinkSync(path);
 		} catch (err) {}
 	});
 	[
+		'tmp/tmp/cwd',
 		'tmp/cwd',
+		'tmp/tmp',
 		'tmp'
-	].forEach(function(path) {
+	].forEach(function (path) {
 		try {
 			fs.rmdirSync(path);
 		} catch (err) {}
@@ -66,6 +69,23 @@ it('should not overwrite when disabled', function (cb) {
 	cpy(['license'], 'tmp', {overwrite: false}, function (err) {
 		assert(!err, err);
 		assert.strictEqual(fs.readFileSync('tmp/license', 'utf8'), '');
+		cb();
+	});
+});
+
+it('should keep path structure', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.mkdirSync('tmp/cwd');
+	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+	cpy(['tmp/cwd/hello.js'], 'tmp', {parents: true}, function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+			fs.readFileSync('tmp/tmp/cwd/hello.js', 'utf8')
+		);
+
 		cb();
 	});
 });


### PR DESCRIPTION
This is the same behavior as `cp` which probably is what most people expects.

Fixes #2.