### PR TITLE
fix cli exit status

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,4 +17,14 @@ var cli = meow({
 	string: ['_']
 });
 
-cpy([cli.input[0]], cli.input[1], {overwrite: cli.flags.overwrite});
+try {
+	cpy([cli.input[0]], cli.input[1], {overwrite: cli.flags.overwrite}, function (err) {
+		if (err) {
+			console.error(err.toLocaleString());
+			process.exit(1);
+		}
+	});
+} catch (err) {
+	console.error(err.toLocaleString());
+	process.exit(1);
+}

--- a/cli.js
+++ b/cli.js
@@ -19,8 +19,12 @@ var cli = meow({
 
 function errorHandler(err) {
 	if (err) {
-		console.error(err.message);
-		process.exit(1);
+		if (err.noStack) {
+			console.error(err.message);
+			process.exit(1);
+		} else {
+			throw err;
+		}
 	}
 }
 

--- a/cli.js
+++ b/cli.js
@@ -17,14 +17,15 @@ var cli = meow({
 	string: ['_']
 });
 
+function errorHandler(err) {
+	if (err) {
+		console.error(err.message);
+		process.exit(1);
+	}
+}
+
 try {
-	cpy([cli.input[0]], cli.input[1], {overwrite: cli.flags.overwrite}, function (err) {
-		if (err) {
-			console.error(err.toLocaleString());
-			process.exit(1);
-		}
-	});
+	cpy([cli.input[0]], cli.input[1], {overwrite: cli.flags.overwrite}, errorHandler);
 } catch (err) {
-	console.error(err.toLocaleString());
-	process.exit(1);
+	errorHandler(err);
 }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ function preprocessDestPath(srcPath, dest, opts) {
 
 module.exports = function (src, dest, opts, cb) {
 	if (!(Array.isArray(src) && src.length > 0) || !dest) {
-		throw new Error('`src` and `dest` required');
+		var err = new Error('`src` and `dest` required');
+		err.noStack = true;
+		throw err;
 	}
 
 	if (typeof opts !== 'object') {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
+var spawnSync = require('child_process').spawnSync;
 var cpy = require('./');
 
 afterEach(function () {
@@ -24,48 +25,61 @@ afterEach(function () {
 	});
 });
 
-it('should copy files', function (cb) {
-	cpy(['license', 'package.json'], 'tmp', function (err) {
-		assert(!err, err);
+describe('api', function() {
+	it('should copy files', function (cb) {
+		cpy(['license', 'package.json'], 'tmp', function (err) {
+			assert(!err, err);
 
-		assert.strictEqual(
-			fs.readFileSync('license', 'utf8'),
-			fs.readFileSync('tmp/license', 'utf8')
-		);
+			assert.strictEqual(
+				fs.readFileSync('license', 'utf8'),
+				fs.readFileSync('tmp/license', 'utf8')
+			);
 
-		assert.strictEqual(
-			fs.readFileSync('package.json', 'utf8'),
-			fs.readFileSync('tmp/package.json', 'utf8')
-		);
+			assert.strictEqual(
+				fs.readFileSync('package.json', 'utf8'),
+				fs.readFileSync('tmp/package.json', 'utf8')
+			);
 
-		cb();
+			cb();
+		});
+	});
+
+	it('should respect cwd', function (cb) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/cwd');
+		fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+		cpy(['hello.js'], 'tmp', {cwd: 'tmp/cwd'}, function (err) {
+			assert(!err, err);
+
+			assert.strictEqual(
+				fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+				fs.readFileSync('tmp/hello.js', 'utf8')
+			);
+
+			cb();
+		});
+	});
+
+	it('should not overwrite when disabled', function (cb) {
+		fs.mkdirSync('tmp');
+		fs.writeFileSync('tmp/license', '');
+
+		cpy(['license'], 'tmp', {overwrite: false}, function (err) {
+			assert(!err, err);
+			assert.strictEqual(fs.readFileSync('tmp/license', 'utf8'), '');
+			cb();
+		});
 	});
 });
 
-it('should respect cwd', function (cb) {
-	fs.mkdirSync('tmp');
-	fs.mkdirSync('tmp/cwd');
-	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
 
-	cpy(['hello.js'], 'tmp', {cwd: 'tmp/cwd'}, function (err) {
-		assert(!err, err);
-
-		assert.strictEqual(
-			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
-			fs.readFileSync('tmp/hello.js', 'utf8')
-		);
-
-		cb();
-	});
-});
-
-it('should not overwrite when disabled', function (cb) {
-	fs.mkdirSync('tmp');
-	fs.writeFileSync('tmp/license', '');
-
-	cpy(['license'], 'tmp', {overwrite: false}, function (err) {
-		assert(!err, err);
-		assert.strictEqual(fs.readFileSync('tmp/license', 'utf8'), '');
-		cb();
+describe('cli', function() {
+	it('should output an error message and return a non-zero exit status on ' +
+		' missing file operands', function () {
+		var sut = spawnSync('./cli.js');
+		var err = String(sut.stderr);
+		assert.ok(sut.status !== 0, 'unexpected exit status: ' + sut.status);
+		assert.notStrictEqual(err, '', err);
 	});
 });

--- a/test.js
+++ b/test.js
@@ -133,8 +133,9 @@ describe('cli', function() {
 		' missing file operands', function (done) {
 		var err = '';
 		var sut = spawn('./cli.js');
+		sut.stderr.setEncoding('utf8');
 		sut.stderr.on('data', function (data) {
-			err += String(data);
+			err += data;
 		});
 		sut.on('close', function(status) {
 			assert.ok(status !== 0, 'unexpected exit status: ' + status);

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
-var spawnSync = require('child_process').spawnSync;
+var spawn = require('child_process').spawn;
 var cpy = require('./');
 
 afterEach(function () {
@@ -76,10 +76,16 @@ describe('api', function() {
 
 describe('cli', function() {
 	it('should output an error message and return a non-zero exit status on ' +
-		' missing file operands', function () {
-		var sut = spawnSync('./cli.js');
-		var err = String(sut.stderr);
-		assert.ok(sut.status !== 0, 'unexpected exit status: ' + sut.status);
-		assert.notStrictEqual(err, '', err);
+		' missing file operands', function (done) {
+		var err = '';
+		var sut = spawn('./cli.js');
+		sut.stderr.on('data', function (data) {
+			err += String(data);
+		});
+		sut.on('close', function(status) {
+			assert.ok(status !== 0, 'unexpected exit status: ' + status);
+			assert.notStrictEqual(err, '', err);
+			done();
+		});
 	});
 });


### PR DESCRIPTION
Node and iojs improved their error messages, hence #5 could be easily fixed:
```sh
$ cpy node_modules/ temp/
Error: EISDIR, open 'temp/node_modules/'
$ echo $?
1
```

Error from `cp-file`:
```sh
$ cpy
Error: `src` and `dest` required
$ echo $?
1
```

Related: https://github.com/iojs/io.js/commit/bc2c85ceef7ac034830e4a4357d0aef69cd6e386
Fixes: #5 