### PR TITLE
parents, dest handling with cwd and handling of absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tmp

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@ var path = require('path');
 var eachAsync = require('each-async');
 var globby = require('globby');
 var cpFile = require('cp-file');
+var pathIsAbsolute = require('path-is-absolute');
 
 function preprocessSrcPath(srcPath, opts) {
-	if (!path.isAbsolute(srcPath) && opts.cwd) {
+	if (!pathIsAbsolute(srcPath) && opts.cwd) {
 		srcPath = path.join(opts.cwd, srcPath);
 	}
 	return srcPath;
@@ -15,7 +16,7 @@ function preprocessDestPath(srcPath, dest, opts) {
 	var basename = path.basename(srcPath);
 	var dirname = path.dirname(srcPath);
 
-	if (!path.isAbsolute(dest) && opts.cwd) {
+	if (!pathIsAbsolute(dest) && opts.cwd) {
 		dest = path.join(opts.cwd, dest);
 	}
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = function (src, dest, opts, cb) {
 		}
 
 		eachAsync(files, function (el, i, next) {
-			cpFile(path.join(cwd, el), path.join(dest, el), opts, next);
+			var file = opts.parents ? el : path.basename(el);
+			cpFile(path.join(cwd, el), path.join(dest, file), opts, next);
 		}, cb);
 	});
 };

--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@ var path = require('path');
 var eachAsync = require('each-async');
 var globby = require('globby');
 var cpFile = require('cp-file');
-var pathIsAbsolute = require('path-is-absolute');
 
 function preprocessSrcPath(srcPath, opts) {
-	if (!pathIsAbsolute(srcPath) && opts.cwd) {
-		srcPath = path.join(opts.cwd, srcPath);
+	if (opts.cwd) {
+		srcPath = path.resolve(opts.cwd, srcPath);
 	}
 	return srcPath;
 }
@@ -16,8 +15,8 @@ function preprocessDestPath(srcPath, dest, opts) {
 	var basename = path.basename(srcPath);
 	var dirname = path.dirname(srcPath);
 
-	if (!pathIsAbsolute(dest) && opts.cwd) {
-		dest = path.join(opts.cwd, dest);
+	if (opts.cwd) {
+		dest = path.resolve(opts.cwd, dest);
 	}
 
 	if (opts.parents) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "meow": "^3.0.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "rimraf": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "cp-file": "^2.0.0",
     "each-async": "^1.1.0",
     "globby": "^1.0.0",
-    "meow": "^3.0.0"
+    "meow": "^3.0.0",
+    "path-is-absolute": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "cp-file": "^2.0.0",
     "each-async": "^1.1.0",
     "globby": "^1.0.0",
-    "meow": "^3.0.0",
-    "path-is-absolute": "^1.0.0"
+    "meow": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,13 @@ Default: `process.cwd()`
 
 The working directory to look for the source files.
 
+##### parents
+
+Type: `boolean`  
+Default: `false`
+
+Keep the path structure when copying files.
+
 
 #### callback(err)
 

--- a/test.js
+++ b/test.js
@@ -87,3 +87,40 @@ it('should not keep path structure by default', function (cb) {
 		cb();
 	});
 });
+
+it('should handle absolute src paths', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.writeFileSync('tmp/hello.js', 'console.log("hello");');
+
+	var src = fs.realpathSync('tmp/hello.js');
+	cpy([src], 'dest', {cwd: 'tmp'}, function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/dest/hello.js', 'utf8'),
+			fs.readFileSync('tmp/hello.js', 'utf8')
+		);
+
+		cb();
+	});
+});
+
+it('should handle absolute dest paths', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.writeFileSync('tmp/hello.js', 'console.log("hello");');
+
+	fs.mkdirSync('tmp/dest');
+	var dest = fs.realpathSync('tmp/dest'); // realpath needs existing path
+	fs.rmdirSync('tmp/dest'); // cpy should create 'dest'
+
+	cpy(['hello.js'], dest, {cwd: 'tmp'}, function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/dest/hello.js', 'utf8'),
+			fs.readFileSync('tmp/hello.js', 'utf8')
+		);
+
+		cb();
+	});
+});

--- a/test.js
+++ b/test.js
@@ -8,16 +8,19 @@ afterEach(function () {
 		'tmp/license',
 		'tmp/package.json',
 		'tmp/cwd/hello.js',
-		'tmp/hello.js'
-	].forEach(function(path) {
+		'tmp/hello.js',
+		'tmp/tmp/cwd/hello.js'
+	].forEach(function (path) {
 		try {
 			fs.unlinkSync(path);
 		} catch (err) {}
 	});
 	[
+		'tmp/tmp/cwd',
 		'tmp/cwd',
+		'tmp/tmp',
 		'tmp'
-	].forEach(function(path) {
+	].forEach(function (path) {
 		try {
 			fs.rmdirSync(path);
 		} catch (err) {}
@@ -66,6 +69,23 @@ it('should not overwrite when disabled', function (cb) {
 	cpy(['license'], 'tmp', {overwrite: false}, function (err) {
 		assert(!err, err);
 		assert.strictEqual(fs.readFileSync('tmp/license', 'utf8'), '');
+		cb();
+	});
+});
+
+it('should keep path structure', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.mkdirSync('tmp/cwd');
+	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+	cpy(['tmp/cwd/hello.js'], 'tmp', {parents: true}, function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+			fs.readFileSync('tmp/tmp/cwd/hello.js', 'utf8')
+		);
+
 		cb();
 	});
 });

--- a/test.js
+++ b/test.js
@@ -2,29 +2,10 @@
 var assert = require('assert');
 var fs = require('fs');
 var cpy = require('./');
+var rimraf = require('rimraf');
 
-afterEach(function () {
-	[
-		'tmp/license',
-		'tmp/package.json',
-		'tmp/cwd/hello.js',
-		'tmp/hello.js',
-		'tmp/tmp/cwd/hello.js'
-	].forEach(function (path) {
-		try {
-			fs.unlinkSync(path);
-		} catch (err) {}
-	});
-	[
-		'tmp/tmp/cwd',
-		'tmp/cwd',
-		'tmp/tmp',
-		'tmp'
-	].forEach(function (path) {
-		try {
-			fs.rmdirSync(path);
-		} catch (err) {}
-	});
+beforeEach(function () {
+	rimraf.sync('tmp');
 });
 
 it('should copy files', function (cb) {
@@ -50,12 +31,12 @@ it('should respect cwd', function (cb) {
 	fs.mkdirSync('tmp/cwd');
 	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
 
-	cpy(['hello.js'], 'tmp', {cwd: 'tmp/cwd'}, function (err) {
+	cpy(['hello.js'], 'dest', {cwd: 'tmp/cwd'}, function (err) {
 		assert(!err, err);
 
 		assert.strictEqual(
-			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
-			fs.readFileSync('tmp/hello.js', 'utf8')
+			fs.readFileSync('tmp/cwd/dest/hello.js', 'utf8'),
+			fs.readFileSync('tmp/cwd/hello.js', 'utf8')
 		);
 
 		cb();

--- a/test.js
+++ b/test.js
@@ -89,3 +89,20 @@ it('should keep path structure', function (cb) {
 		cb();
 	});
 });
+
+it('should not keep path structure by default', function (cb) {
+	fs.mkdirSync('tmp');
+	fs.mkdirSync('tmp/cwd');
+	fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+	cpy(['tmp/cwd/hello.js'], 'tmp', function (err) {
+		assert(!err, err);
+
+		assert.strictEqual(
+			fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+			fs.readFileSync('tmp/hello.js', 'utf8')
+		);
+
+		cb();
+	});
+});


### PR DESCRIPTION
This PR is on top of @kevva PR #4.

To sum it up:
1. change *parents* behavior as discussed in #2 (incl. missing test mentioned in [#4 comment](https://github.com/sindresorhus/cpy/pull/4#issuecomment-75375893))
2. fix wrong dest handling with cwd
3. fix handling of absolute paths

About 2.:
```js
cpy(['hello.js'], 'dest', {cwd: 'cwd'} ...)
```
should copy the file `cwd/hello.js` to `cwd/dest/hello.js`, but copies to `dest/hello.js` atm.