### PR TITLE
RFC: improved error messages

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,7 @@ var cli = meow({
 
 function errorHandler(err) {
 	if (err) {
-		if (err.noStack) {
+		if (err.name === 'CpyError') {
 			console.error(err.message);
 			process.exit(1);
 		} else {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "cp-file": "^2.0.0",
     "each-async": "^1.1.0",
     "globby": "^1.0.0",
-    "meow": "^3.0.0"
+    "meow": "^3.0.0",
+    "verror": "^1.6.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "each-async": "^1.1.0",
     "globby": "^1.0.0",
     "meow": "^3.0.0",
-    "verror": "^1.6.0"
+    "nested-error-stacks": "0.0.4",
+    "object-assign": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This is an attempt to provide better error messages, but w/o the `err.noStack` workaround (introduced by #7) and is based on improvements by https://github.com/sindresorhus/cp-file/pull/6.

New Error messages would look like this:
```sh
$ cpy 
`src` and `dest` required

$ cpy / tmp
cannot copy from '/' to 'tmp': cannot read from '/': EISDIR, read

$ cpy /etc/shadow tmp
cannot copy from '/etc/shadow' to 'tmp/shadow': cannot read from '/etc/shadow': EACCES, open '/etc/shadow'
```

About the [verror](https://github.com/davepacheco/node-verror) package I've used, please comment at https://github.com/sindresorhus/cp-file/pull/6.