### PR TITLE
enhance CLI to set cwd and whether or not to keep path structure

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,12 +6,14 @@ var cpy = require('./');
 var cli = meow({
 	help: [
 		'Usage',
-		'  $ cpy <source> <destination> [--no-overwrite]',
+		'  $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd <dir>]',
 		'',
 		'Example',
 		'  $ cpy \'src/*.png\' dist',
 		'',
-		'<source> can contain globs if quoted'
+		'<source> can contain globs if quoted',
+		'--parents whether or not to keep path structure',
+		'--cwd <dir> the working directory to look for the source files'
 	].join('\n')
 }, {
 	string: ['_']
@@ -29,7 +31,11 @@ function errorHandler(err) {
 }
 
 try {
-	cpy([cli.input[0]], cli.input[1], {overwrite: cli.flags.overwrite}, errorHandler);
+	cpy([cli.input[0]], cli.input[1], {
+		cwd: cli.flags.cwd || process.cwd(),
+		parents: !!cli.flags.parents,
+		overwrite: cli.flags.overwrite
+	}, errorHandler);
 } catch (err) {
 	errorHandler(err);
 }

--- a/test.js
+++ b/test.js
@@ -145,4 +145,36 @@ describe('cli', function () {
 			done();
 		});
 	});
+
+	it('should keep path structure with flag "--parents"', function (done) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/cwd');
+		fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+		var sut = spawn('./cli.js', ['tmp/cwd/hello.js', 'tmp', '--parents'])
+		sut.on('close', function (status) {
+			assert.ok(status === 0, 'unexpected exit status: ' + status);
+			assert.strictEqual(
+				fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+				fs.readFileSync('tmp/tmp/cwd/hello.js', 'utf8')
+			);
+			done();
+		});
+	});
+
+	it('should respect cwd', function (done) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/cwd');
+		fs.writeFileSync('tmp/cwd/hello.js', 'console.log("hello");');
+
+		var sut = spawn('./cli.js', ['cwd/hello.js', 'dest', '--cwd', 'tmp'])
+		sut.on('close', function (status) {
+			assert.ok(status === 0, 'unexpected exit status: ' + status);
+			assert.strictEqual(
+				fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
+				fs.readFileSync('tmp/dest/hello.js', 'utf8')
+			);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
This PR adds 2 things to CLI
* specify the current CWD, default to process.cwd()
* specify whether to keep path structure

Both are already supported by the Node API.