### PR TITLE
--rename option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,14 +6,15 @@ var cpy = require('./');
 var cli = meow({
 	help: [
 		'Usage',
-		'  $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd <dir>]',
+		'  $ cpy <source> [--rename <filename>] <destination> [--no-overwrite] [--parents] [--cwd <dir>]',
 		'',
 		'Example',
 		'  $ cpy \'src/*.png\' dist',
 		'',
 		'Options',
-		'  --parents    Preseve path structure',
-		'  --cwd <dir>  Working directory for source files',
+		'  --rename <filename>  Rename all <source> filenames to <filename>',
+		'  --parents            Preseve path structure',
+		'  --cwd <dir>          Working directory for source files',
 		'',
 		'<source> can contain globs if quoted',
 	].join('\n')
@@ -35,6 +36,7 @@ function errorHandler(err) {
 try {
 	cpy([cli.input[0]], cli.input[1], {
 		cwd: cli.flags.cwd || process.cwd(),
+		rename: cli.flags.rename,
 		parents: cli.flags.parents,
 		overwrite: cli.flags.overwrite
 	}, errorHandler);

--- a/cli.js
+++ b/cli.js
@@ -6,15 +6,15 @@ var cpy = require('./');
 var cli = meow({
 	help: [
 		'Usage',
-		'  $ cpy <source> [--rename <filename>] <destination> [--no-overwrite] [--parents] [--cwd <dir>]',
+		'  $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd <dir>] [--rename=<filename>]',
 		'',
 		'Example',
 		'  $ cpy \'src/*.png\' dist',
 		'',
 		'Options',
-		'  --rename <filename>  Rename all <source> filenames to <filename>',
 		'  --parents            Preseve path structure',
 		'  --cwd <dir>          Working directory for source files',
+		'  --rename=<filename>  Rename all <source> filenames to <filename>',
 		'',
 		'<source> can contain globs if quoted',
 	].join('\n')

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function preprocessSrcPath(srcPath, opts) {
 }
 
 function preprocessDestPath(srcPath, dest, opts) {
-	var basename = opts.rename ? opts.rename : path.basename(srcPath);
+	var basename = opts.rename || path.basename(srcPath);
 	var dirname = path.dirname(srcPath);
 
 	if (opts.cwd) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function preprocessSrcPath(srcPath, opts) {
 }
 
 function preprocessDestPath(srcPath, dest, opts) {
-	var basename = path.basename(srcPath);
+	var basename = opts.rename ? opts.rename : path.basename(srcPath);
 	var dirname = path.dirname(srcPath);
 
 	if (opts.cwd) {

--- a/readme.md
+++ b/readme.md
@@ -50,12 +50,6 @@ Type: `object`
 
 Options are passed to [cp-file](https://github.com/sindresorhus/cp-file#options) and [glob](https://github.com/isaacs/node-glob#options).
 
-##### rename
-
-Type: `string`
-
-The filename which is used to rename every file in `files`.
-
 ##### cwd
 
 Type: `string`  
@@ -70,6 +64,11 @@ Default: `false`
 
 Keep the path structure when copying files.
 
+##### rename
+
+Type: `string`
+
+The filename which is used to rename every file in `files`.
 
 #### callback(err)
 
@@ -86,15 +85,15 @@ $ npm install --global cpy
 $ cpy --help
 
   Usage
-    $ cpy <source> [--rename <filename>] <destination> [--no-overwrite] [--parents] [--cwd <dir>]
+    $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd <dir>] [--rename=<filename>]
 
   Example
     $ cpy 'src/*.png' dist
 
   Options
-    --rename <filename>  Rename all <source> filenames to <filename>
     --parents            Preseve path structure
     --cwd <dir>          Working directory for source files
+    --rename=<filename>  Rename all <source> filenames to <filename>
 
   <source> can contain globs if quoted
 ```

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,12 @@ Type: `object`
 
 Options are passed to [cp-file](https://github.com/sindresorhus/cp-file#options) and [glob](https://github.com/isaacs/node-glob#options).
 
+##### rename
+
+Type: `string`
+
+The filename which is used to rename every file in `files`.
+
 ##### cwd
 
 Type: `string`
@@ -80,14 +86,15 @@ $ npm install --global cpy
 $ cpy --help
 
   Usage
-    $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd <dir>]
+    $ cpy <source> [--rename <filename>] <destination> [--no-overwrite] [--parents] [--cwd <dir>]
 
   Example
     $ cpy 'src/*.png' dist
 
   Options
-    --parents    Preseve path structure
-    --cwd <dir>  Working directory for source files
+    --rename <filename>  Rename all <source> filenames to <filename>
+    --parents            Preseve path structure
+    --cwd <dir>          Working directory for source files
 
   <source> can contain globs if quoted
 ```

--- a/readme.md
+++ b/readme.md
@@ -32,14 +32,14 @@ cpy(['src/*.png'], 'dist', function (err) {
 
 #### files
 
-*Required*
+*Required*  
 Type: `array`
 
 Files to copy.
 
 #### destination
 
-*Required*
+*Required*  
 Type: `string`
 
 Destination directory.
@@ -58,14 +58,14 @@ The filename which is used to rename every file in `files`.
 
 ##### cwd
 
-Type: `string`
+Type: `string`  
 Default: `process.cwd()`
 
 The working directory to look for the source files.
 
 ##### parents
 
-Type: `boolean`
+Type: `boolean`  
 Default: `false`
 
 Keep the path structure when copying files.

--- a/readme.md
+++ b/readme.md
@@ -32,14 +32,14 @@ cpy(['src/*.png'], 'dist', function (err) {
 
 #### files
 
-*Required*  
+*Required*
 Type: `array`
 
 Files to copy.
 
 #### destination
 
-*Required*  
+*Required*
 Type: `string`
 
 Destination directory.
@@ -52,14 +52,14 @@ Options are passed to [cp-file](https://github.com/sindresorhus/cp-file#options)
 
 ##### cwd
 
-Type: `string`  
+Type: `string`
 Default: `process.cwd()`
 
 The working directory to look for the source files.
 
 ##### parents
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Keep the path structure when copying files.

--- a/test.js
+++ b/test.js
@@ -126,6 +126,32 @@ describe('api', function () {
 			cb();
 		});
 	});
+
+	it('should rename filenames (but not filepaths)', function (cb) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/src');
+
+		fs.writeFileSync('tmp/hello.js', 'console.log("hello");');
+		fs.writeFileSync('tmp/src/hello.js', 'console.log("src/hello");');
+
+		var opts = {cwd: 'tmp', parents: true, rename: 'hi.js'};
+
+		cpy(['hello.js', 'src/hello.js'], 'dest/subdir', opts, function (err) {
+			assert(!err, err);
+
+			assert.strictEqual(
+				fs.readFileSync('tmp/dest/subdir/hi.js', 'utf8'),
+				fs.readFileSync('tmp/hello.js', 'utf8')
+			);
+
+			assert.strictEqual(
+				fs.readFileSync('tmp/dest/subdir/src/hi.js', 'utf8'),
+				fs.readFileSync('tmp/src/hello.js', 'utf8')
+			);
+
+			cb();
+		});
+	});
 });
 
 describe('cli', function () {
@@ -173,6 +199,22 @@ describe('cli', function () {
 			assert.strictEqual(
 				fs.readFileSync('tmp/cwd/hello.js', 'utf8'),
 				fs.readFileSync('tmp/dest/hello.js', 'utf8')
+			);
+			done();
+		});
+	});
+
+	it('should rename files', function (done) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/dest');
+		fs.writeFileSync('tmp/hello.js', 'console.log("hello");');
+
+		var sut = spawn('./cli.js', ['tmp/hello.js', '--rename', 'hi.js', 'tmp/dest'])
+		sut.on('close', function (status) {
+			assert.ok(status === 0, 'unexpected exit status: ' + status);
+			assert.strictEqual(
+				fs.readFileSync('tmp/hello.js', 'utf8'),
+				fs.readFileSync('tmp/dest/hi.js', 'utf8')
 			);
 			done();
 		});

--- a/test.js
+++ b/test.js
@@ -209,7 +209,7 @@ describe('cli', function () {
 		fs.mkdirSync('tmp/dest');
 		fs.writeFileSync('tmp/hello.js', 'console.log("hello");');
 
-		var sut = spawn('./cli.js', ['tmp/hello.js', '--rename', 'hi.js', 'tmp/dest'])
+		var sut = spawn('./cli.js', ['tmp/hello.js', 'tmp/dest', '--rename=hi.js'])
 		sut.on('close', function (status) {
 			assert.ok(status === 0, 'unexpected exit status: ' + status);
 			assert.strictEqual(


### PR DESCRIPTION
At the moment, only simple string-based renaming is possible:
```bash
$ cpy "src/*.js" --rename hi.js dest --parents

$ tree
.
├── dest
│   └── src
│       └── hi.js
└── src
    └── hello.js
```
As can be seen, the destination _directory path_ remains untouched, only the _basename_ changes.