### PR TITLE
Supporting multiple globs on cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ var cli = meow({
 		'  $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd=<dir>] [--rename=<filename>]',
 		'',
 		'Example',
-		'  $ cpy \'src/*.png\' dist',
+		'  $ cpy \'src/*.png\' \'!src/goat.png\' dist',
 		'',
 		'Options',
 		'  --no-overwrite       Don\'t overwrite the destination',
@@ -35,7 +35,8 @@ function errorHandler(err) {
 }
 
 try {
-	cpy([cli.input[0]], cli.input[1], {
+	var dest = cli.input.pop();
+	cpy(cli.input, dest, {
 		cwd: cli.flags.cwd || process.cwd(),
 		rename: cli.flags.rename,
 		parents: cli.flags.parents,

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ $ cpy --help
     $ cpy <source> <destination> [--no-overwrite] [--parents] [--cwd=<dir>] [--rename=<filename>]
 
   Example
-    $ cpy 'src/*.png' dist
+    $ cpy 'src/*.png' '!src/goat.png' dist
 
   Options
     --no-overwrite       Don't overwrite the destination

--- a/test.js
+++ b/test.js
@@ -236,4 +236,25 @@ describe('cli', function () {
 			done();
 		});
 	});
+
+	it('should not copy files in the negated glob patterns', function (done) {
+		fs.mkdirSync('tmp');
+		fs.mkdirSync('tmp/src');
+		fs.mkdirSync('tmp/dest');
+		fs.writeFileSync('tmp/src/hello.js', 'console.log("hello");');
+		fs.writeFileSync('tmp/src/hello.jsx', 'console.log("world");');
+		fs.writeFileSync('tmp/src/hello.es6', 'console.log("world");');
+
+		var sut = spawn('./cli.js', ['tmp/src/*.*', '!tmp/src/*.jsx', '!tmp/src/*.es6', 'tmp/dest'])
+		sut.on('close', function (status) {
+			assert.ok(status === 0, 'unexpected exit status: ' + status);
+			assert.strictEqual(
+				fs.readFileSync('tmp/dest/hello.js', 'utf8'),
+				'console.log("hello");'
+			);
+			assert.ok(!fs.existsSync('tmp/dest/hello.jsx'));
+			assert.ok(!fs.existsSync('tmp/dest/hello.es6'));
+			done();
+		});
+	});
 });


### PR DESCRIPTION
It's related to https://github.com/sindresorhus/cpy/issues/17. I'm using '|' delimiter to separate the source string to make an array for globs. I think the way of using delimiter is more easy to users