### PR TITLE
Use bash-style behavior, if src pattern does not match.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,8 @@ try {
 		cwd: cli.flags.cwd || process.cwd(),
 		rename: cli.flags.rename,
 		parents: cli.flags.parents,
-		overwrite: cli.flags.overwrite !== false
+		overwrite: cli.flags.overwrite !== false,
+		nonull: true,
 	}, errorHandler);
 } catch (err) {
 	errorHandler(err);

--- a/test.js
+++ b/test.js
@@ -156,7 +156,7 @@ describe('api', function () {
 
 describe('cli', function () {
 	it('should output an error message and return a non-zero exit status on ' +
-		' missing file operands', function (done) {
+		'missing file operands', function (done) {
 		var err = '';
 		var sut = spawn('./cli.js');
 
@@ -168,6 +168,23 @@ describe('cli', function () {
 		sut.on('close', function (status) {
 			assert.ok(status !== 0, 'unexpected exit status: ' + status);
 			assert.strictEqual(err.trim(), '`src` and `dest` required', err);
+			done();
+		});
+	});
+
+	it('should output an error message and return a non-zero exit status if ' +
+		'source file does not exist', function (done) {
+		var err = '';
+		var sut = spawn('./cli.js', ['tmp/nonexistentfile', 'tmp']);
+
+		sut.stderr.setEncoding('utf8');
+		sut.stderr.on('data', function (data) {
+			err += data;
+		});
+
+		sut.on('close', function (status) {
+			assert.ok(status !== 0, 'unexpected exit status: ' + status);
+			assert.ok(/nonexistentfile/.test(err), err);
 			done();
 		});
 	});


### PR DESCRIPTION
See [nonull:true](https://github.com/isaacs/node-glob#empty-sets).
