### PR TITLE
Allow non-array argument by wrapping into new array

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,11 @@ function preprocessDestPath(srcPath, dest, opts) {
 }
 
 module.exports = function (src, dest, opts) {
-	if (!(Array.isArray(src) && src.length > 0) || !dest) {
+	if (!Array.isArray(src)) {
+		src = [src];
+	}
+
+	if (!(src.length > 0) || !dest) {
 		return Promise.reject(new CpyError('`src` and `dest` required'));
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ cpy(['src/*.png', '!src/goat.png'], 'dist').then(() => {
 
 #### files
 
-Type: `array`
+Type: `array` of strings or a single `string`
 
 Files to copy.
 

--- a/test.js
+++ b/test.js
@@ -12,11 +12,17 @@ test.beforeEach(t => {
 	t.context.tmp = tempfile();
 });
 
-test('copy files', async t => {
+test('copy array of files', async t => {
 	await fn(['license', 'package.json'], t.context.tmp);
 
 	t.is(read('license'), read(t.context.tmp, 'license'));
 	t.is(read('package.json'), read(t.context.tmp, 'package.json'));
+});
+
+test('copy single file', async t => {
+	await fn('license', t.context.tmp);
+
+	t.is(read('license'), read(t.context.tmp, 'license'));
 });
 
 test('cwd', async t => {


### PR DESCRIPTION
Allow `cpy('src-file', 'dist')` instead of throwing error.

Simply wrap `src-file` into array and move on. ;)