### PR TITLE
Allow rename to be a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,14 @@ const CpyError = require('./cpy-error');
 const preprocessSrcPath = (srcPath, opts) => opts.cwd ? path.resolve(opts.cwd, srcPath) : srcPath;
 
 const preprocessDestPath = (srcPath, dest, opts) => {
-	const basename = opts.rename || path.basename(srcPath);
+	let basename = path.basename(srcPath);
 	const dirname = path.dirname(srcPath);
+
+	if (typeof opts.rename === 'string') {
+		basename = opts.rename;
+	} else if (typeof opts.rename === 'function') {
+		basename = opts.rename(basename);
+	}
 
 	if (opts.cwd) {
 		dest = path.resolve(opts.cwd, dest);

--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,9 @@ Preserve path structure.
 
 ##### rename
 
-Type: `string`
+Type: `string`, `function`
 
-Filename used to rename every file in `files`.
+Filename or function returning a filename used to rename every file in `files`.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -105,6 +105,24 @@ test('rename filenames but not filepaths', async t => {
 	t.is(read(t.context.tmp, 'src/hello.js'), read(t.context.tmp, 'dest/subdir/src/hi.js'));
 });
 
+test('rename filenames using a function', async t => {
+	fs.mkdirSync(t.context.tmp);
+	fs.mkdirSync(path.join(t.context.tmp, 'src'));
+	fs.writeFileSync(path.join(t.context.tmp, 'foo.js'), 'console.log("foo");');
+	fs.writeFileSync(path.join(t.context.tmp, 'src/bar.js'), 'console.log("bar");');
+
+	await fn(['foo.js', 'src/bar.js'], 'dest/subdir', {
+		cwd: t.context.tmp,
+		parents: true,
+		rename(basename) {
+			return 'prefix-' + basename;
+		}
+	});
+
+	t.is(read(t.context.tmp, 'foo.js'), read(t.context.tmp, 'dest/subdir/prefix-foo.js'));
+	t.is(read(t.context.tmp, 'src/bar.js'), read(t.context.tmp, 'dest/subdir/src/prefix-bar.js'));
+});
+
 test('cp-file errors are not glob errors', async t => {
 	const err = await t.throws(fn('license', t.context.EPERM), /EPERM/);
 	t.notRegex(err, /glob/);


### PR DESCRIPTION
Having a single filename wasn't very flexible for renaming files as you copied them.