### PR TITLE
Fix return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ module.exports = (src, dest, options = {}) => {
 	let stats = {
 		totalFiles: 0,
 		percent: 1,
-		completedFiles: 0,
-		completedSize: 0
+		completedFiles,
+		completedSize
 	};
 
 	const promise = globby(src, options)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cpy",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"description": "Copy files",
 	"license": "MIT",
 	"repository": "sindresorhus/cpy",

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ $ npm install cpy
 const cpy = require('cpy');
 
 (async () => {
-	await cpy(['src/*.png', '!src/goat.png'], 'dist');
-	console.log('Files copied!');
+	const stats = await cpy(['src/*.png', '!src/goat.png'], 'dist');
+	console.log(`Copied ${stats.completedFiles} files!`);
 })();
 ```
 
@@ -81,6 +81,8 @@ cpy('foo.js', 'destination', {
 
 
 ## Progress reporting
+Final statistics will always be returned from `cpy()` function. 
+For on-going progress, you can use the `progress` event.
 
 ### cpy.on('progress', handler)
 

--- a/test.js
+++ b/test.js
@@ -222,3 +222,10 @@ test('returns the event emitter on early rejection', t => {
 	t.is(typeof rejectedPromise.on, 'function');
 	rejectedPromise.catch(() => {});
 });
+
+test('returns final progress stats', async t => {
+	const result = await fn(['license', 'package.json'], t.context.tmp);
+	t.is(result.totalFiles, 2);
+	t.is(result.percent, 1);
+	t.is(result.completedFiles, 2);
+});


### PR DESCRIPTION
`cpy()` returns a weird `[ [undefined, undefined, undefined] ]` from inner `Promise.all` call.
Fixed by returning the final statistics from progress emitter.