### PR TITLE
WIP: Fix windows tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ const read = (...args) => fs.readFileSync(path.join(...args), 'utf8');
 test.beforeEach(t => {
 	t.context.tmp = tempfile();
 	if (process.platform === 'win32') {
-		t.context.EPERM = 'C:\\Windows\\System32'
+		t.context.EPERM = 'C:\\Windows\\System32';
 	} else {
 		t.context.EPERM = tempfile('EPERM');
 		fs.mkdirSync(t.context.EPERM, 0);
@@ -85,7 +85,6 @@ test('do not keep path structure', async t => {
 });
 
 test('path structure', async t => {
-	debugger
 	fs.mkdirSync(t.context.tmp);
 	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));
 	fs.writeFileSync(path.join(t.context.tmp, 'cwd', 'hello.js'), 'console.log("hello");');


### PR DESCRIPTION
Fixes #64

As noted in [my comment](https://github.com/sindresorhus/cpy/issues/64#issuecomment-502826054) there were issues with some of the tests on Windows due to EPERM errors not being thrown, these are now fixed.

There is another test breaking `path structure` which I'm currently looking in to, this seems like a bug when the `parents` flag is set on Windows.

Error message:

```
Path contains invalid characters: C:\\Users\\Tom\\AppData\\Local\\Temp\\0aaaa95a-dc38-4fd8-8ac1-1c8ae27271ee\\C:\\Users\\Tom\\AppData\\Local\\Temp\\0aaaa95a-dc38-4fd8-8ac1-1c8ae27271ee\\cwd
```

