### PR TITLE
Add `ignoreJunk` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,13 @@ declare namespace cpy {
 		@default (os.cpus().length || 1) * 2
 		*/
 		readonly concurrency?: number;
+
+		/**
+		Ignore junk files.
+
+		@default true
+		*/
+		readonly ignoreJunk?: boolean;
 	}
 
 	interface ProgressData {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ const pAll = require('p-all');
 const arrify = require('arrify');
 const globby = require('globby');
 const cpFile = require('cp-file');
+const junk = require('junk');
 const CpyError = require('./cpy-error');
+
+const defaultOptions = {
+	ignoreJunk: true
+};
 
 const preprocessSourcePath = (source, options) => options.cwd ? path.resolve(options.cwd, source) : source;
 
@@ -36,6 +41,7 @@ module.exports = (source, destination, {
 	...options
 } = {}) => {
 	const progressEmitter = new EventEmitter();
+	options = {...defaultOptions, ...options};
 
 	const promise = (async () => {
 		source = arrify(source);
@@ -51,6 +57,10 @@ module.exports = (source, destination, {
 		let files;
 		try {
 			files = await globby(source, options);
+
+			if (options.ignoreJunk) {
+				files = files.filter(file => junk.not(path.basename(file)));
+			}
 		} catch (error) {
 			throw new CpyError(`Cannot glob \`${source}\`: ${error.message}`, error);
 		}

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-    "name": "cpy",
-    "version": "7.3.0",
-    "description": "Copy files",
-    "license": "MIT",
-    "repository": "sindresorhus/cpy",
-    "author": {
-        "name": "Sindre Sorhus",
-        "email": "sindresorhus@gmail.com",
-        "url": "sindresorhus.com"
-    },
-    "engines": {
-        "node": ">=8"
-    },
-    "scripts": {
-        "test": "xo && ava && tsd"
-    },
-    "files": [
-        "cpy-error.js",
-        "index.js",
-        "index.d.ts"
-    ],
-    "keywords": [
-        "copy",
-        "cp",
-        "cpy",
-        "file",
-        "files",
-        "clone",
-        "fs",
-        "stream",
-        "glob",
-        "file-system",
-        "ncp",
-        "fast",
-        "quick",
-        "data",
-        "content",
-        "contents",
-        "cpx",
-        "directory",
-        "directories"
-    ],
-    "dependencies": {
-        "arrify": "^2.0.1",
-        "cp-file": "^7.0.0",
-        "globby": "^9.2.0",
-        "nested-error-stacks": "^2.1.0",
-        "p-all": "^2.1.0",
-        "junk": "^3.1.0"
-    },
-    "devDependencies": {
-        "ava": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "tempfile": "^3.0.0",
-        "tsd": "^0.7.2",
-        "xo": "^0.24.0"
-    }
+	"name": "cpy",
+	"version": "7.3.0",
+	"description": "Copy files",
+	"license": "MIT",
+	"repository": "sindresorhus/cpy",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"engines": {
+		"node": ">=8"
+	},
+	"scripts": {
+		"test": "xo && ava && tsd"
+	},
+	"files": [
+		"cpy-error.js",
+		"index.js",
+		"index.d.ts"
+	],
+	"keywords": [
+		"copy",
+		"cp",
+		"cpy",
+		"file",
+		"files",
+		"clone",
+		"fs",
+		"stream",
+		"glob",
+		"file-system",
+		"ncp",
+		"fast",
+		"quick",
+		"data",
+		"content",
+		"contents",
+		"cpx",
+		"directory",
+		"directories"
+	],
+	"dependencies": {
+		"arrify": "^2.0.1",
+		"cp-file": "^7.0.0",
+		"globby": "^9.2.0",
+		"nested-error-stacks": "^2.1.0",
+		"p-all": "^2.1.0",
+		"junk": "^3.1.0"
+	},
+	"devDependencies": {
+		"ava": "^2.1.0",
+		"rimraf": "^2.6.3",
+		"tempfile": "^3.0.0",
+		"tsd": "^0.7.2",
+		"xo": "^0.24.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,58 +1,59 @@
 {
-	"name": "cpy",
-	"version": "7.3.0",
-	"description": "Copy files",
-	"license": "MIT",
-	"repository": "sindresorhus/cpy",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
-	},
-	"engines": {
-		"node": ">=8"
-	},
-	"scripts": {
-		"test": "xo && ava && tsd"
-	},
-	"files": [
-		"cpy-error.js",
-		"index.js",
-		"index.d.ts"
-	],
-	"keywords": [
-		"copy",
-		"cp",
-		"cpy",
-		"file",
-		"files",
-		"clone",
-		"fs",
-		"stream",
-		"glob",
-		"file-system",
-		"ncp",
-		"fast",
-		"quick",
-		"data",
-		"content",
-		"contents",
-		"cpx",
-		"directory",
-		"directories"
-	],
-	"dependencies": {
-		"arrify": "^2.0.1",
-		"cp-file": "^7.0.0",
-		"globby": "^9.2.0",
-		"nested-error-stacks": "^2.1.0",
-		"p-all": "^2.1.0"
-	},
-	"devDependencies": {
-		"ava": "^2.1.0",
-		"rimraf": "^2.6.3",
-		"tempfile": "^3.0.0",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
-	}
+    "name": "cpy",
+    "version": "7.3.0",
+    "description": "Copy files",
+    "license": "MIT",
+    "repository": "sindresorhus/cpy",
+    "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+    },
+    "engines": {
+        "node": ">=8"
+    },
+    "scripts": {
+        "test": "xo && ava && tsd"
+    },
+    "files": [
+        "cpy-error.js",
+        "index.js",
+        "index.d.ts"
+    ],
+    "keywords": [
+        "copy",
+        "cp",
+        "cpy",
+        "file",
+        "files",
+        "clone",
+        "fs",
+        "stream",
+        "glob",
+        "file-system",
+        "ncp",
+        "fast",
+        "quick",
+        "data",
+        "content",
+        "contents",
+        "cpx",
+        "directory",
+        "directories"
+    ],
+    "dependencies": {
+        "arrify": "^2.0.1",
+        "cp-file": "^7.0.0",
+        "globby": "^9.2.0",
+        "nested-error-stacks": "^2.1.0",
+        "p-all": "^2.1.0",
+        "junk": "^3.1.0"
+    },
+    "devDependencies": {
+        "ava": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "tempfile": "^3.0.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,12 @@ Default: `(os.cpus().length || 1) * 2`
 
 Number of files being copied concurrently.
 
+##### ignoreJunk
+
+Type: `boolean`<br>
+Default: `true`
+
+Ignores [junk](https://github.com/sindresorhus/junk) files.
 
 ## Progress reporting
 

--- a/test.js
+++ b/test.js
@@ -157,6 +157,66 @@ test('reports copy progress of no files', async t => {
 	t.is(report.percent, 1);
 });
 
+test('junk files are ignored', async t => {
+	fs.mkdirSync(t.context.tmp);
+	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/Thumbs.db'), 'lorem ipsum');
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/foo'), 'lorem ipsum');
+
+	let report;
+
+	await cpy('*', t.context.tmp, {cwd: path.join(t.context.tmp, 'cwd'), ignoreJunk: true})
+		.on('progress', event => {
+			report = event;
+		});
+
+	t.not(report, undefined);
+	t.is(report.totalFiles, 1);
+	t.is(report.completedFiles, 1);
+	t.is(report.completedSize, 11);
+	t.is(report.percent, 1);
+});
+
+test('junk files are copied', async t => {
+	fs.mkdirSync(t.context.tmp);
+	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/Thumbs.db'), 'lorem ipsum');
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/foo'), 'lorem ipsum');
+
+	let report;
+
+	await cpy('*', t.context.tmp, {cwd: path.join(t.context.tmp, 'cwd'), ignoreJunk: false})
+		.on('progress', event => {
+			report = event;
+		});
+
+	t.not(report, undefined);
+	t.is(report.totalFiles, 2);
+	t.is(report.completedFiles, 2);
+	t.is(report.completedSize, 22);
+	t.is(report.percent, 1);
+});
+
+test('nested junk files are ignored', async t => {
+	fs.mkdirSync(t.context.tmp);
+	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/Thumbs.db'), 'lorem ispum');
+	fs.writeFileSync(path.join(t.context.tmp, 'cwd/test'), 'lorem ispum');
+
+	let report;
+
+	await cpy(['cwd/Thumbs.db', 'cwd/test'], t.context.tmp, {cwd: t.context.tmp, ignoreJunk: true})
+		.on('progress', event => {
+			report = event;
+		});
+
+	t.not(report, undefined);
+	t.is(report.totalFiles, 1);
+	t.is(report.completedFiles, 1);
+	t.is(report.completedSize, 11);
+	t.is(report.percent, 1);
+});
+
 test('reports copy progress of single file', async t => {
 	fs.mkdirSync(t.context.tmp);
 	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));


### PR DESCRIPTION
@sindresorhus 
Fixes #57 

- Added `ignoreJunk` option, defaults to `false`
- Updated readme, included tests

One thing i encountered when writing tests for this. If you glob using `*`, hidden files will be [ignored](https://github.com/mrmlnc/fast-glob#basic-syntax) by default.