### PR TITLE
Add `concurrency` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare namespace cpy {
 		/**
 		Number of files being copied concurrently.
 
-		@default "(os.cpus().length || 1) * 2"
+		@default (os.cpus().length || 1) * 2
 		*/
 		readonly concurrency?: number;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,13 @@ declare namespace cpy {
 		```
 		*/
 		readonly rename?: string | ((basename: string) => string);
+
+		/**
+		Number of files being copied concurrently.
+
+		@default "(os.cpus().length || 1) * 2"
+		*/
+		readonly concurrency?: number;
 	}
 
 	interface ProgressData {

--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ module.exports = (source, destination, options = {}) => {
 				} catch (error) {
 					throw new CpyError(`Cannot copy from \`${from}\` to \`${to}\`: ${error.message}`, error);
 				}
+
+				return to;
 			};
 		}), {concurrency: concurrencyDegree});
 	})();

--- a/index.js
+++ b/index.js
@@ -41,8 +41,6 @@ module.exports = (source, destination, options = {}) => {
 		concurrencyDegree = (os.cpus().length || 1) * 2;
 	}
 
-	console.log(`Concurrency degree is: ${concurrencyDegree}.`);
-
 	const promise = (async () => {
 		source = arrify(source);
 
@@ -71,7 +69,7 @@ module.exports = (source, destination, options = {}) => {
 		}
 
 		const fileProgressHandler = event => {
-			const fileStatus = copyStatus.get(event.src) || { written: 0, percent: 0 };
+			const fileStatus = copyStatus.get(event.src) || {written: 0, percent: 0};
 
 			if (fileStatus.written !== event.written || fileStatus.percent !== event.percent) {
 				completedSize -= fileStatus.written;
@@ -95,8 +93,8 @@ module.exports = (source, destination, options = {}) => {
 			}
 		};
 
-		return pAll(files.map(async sourcePath => {
-			const operation = async () => {
+		return pAll(files.map(sourcePath => {
+			return async () => {
 				const from = preprocessSourcePath(sourcePath, options);
 				const to = preprocessDestinationPath(sourcePath, destination, options);
 
@@ -105,10 +103,8 @@ module.exports = (source, destination, options = {}) => {
 				} catch (error) {
 					throw new CpyError(`Cannot copy from \`${from}\` to \`${to}\`: ${error.message}`, error);
 				}
-			}
-
-			return operation;
-		}), { concurrency: concurrencyDegree });
+			};
+		}), {concurrency: concurrencyDegree});
 	})();
 
 	promise.on = (...arguments_) => {

--- a/index.js
+++ b/index.js
@@ -31,9 +31,11 @@ const preprocessDestinationPath = (source, destination, options) => {
 	return path.join(destination, basename);
 };
 
-module.exports = (source, destination, options = {}) => {
+module.exports = (source, destination, {
+	concurrency = (os.cpus().lengh || 1) * 2,
+	...options
+} = {}) => {
 	const progressEmitter = new EventEmitter();
-	const concurrency = options.concurrency || (os.cpus().length || 1) * 2;
 
 	const promise = (async () => {
 		source = arrify(source);

--- a/index.js
+++ b/index.js
@@ -33,13 +33,7 @@ const preprocessDestinationPath = (source, destination, options) => {
 
 module.exports = (source, destination, options = {}) => {
 	const progressEmitter = new EventEmitter();
-	let concurrencyDegree;
-
-	if (options.concurrency) {
-		concurrencyDegree = options.concurrency;
-	} else {
-		concurrencyDegree = (os.cpus().length || 1) * 2;
-	}
+	const concurrency = options.concurrency || (os.cpus().length || 1) * 2;
 
 	const promise = (async () => {
 		source = arrify(source);
@@ -106,7 +100,7 @@ module.exports = (source, destination, options = {}) => {
 
 				return to;
 			};
-		}), {concurrency: concurrencyDegree});
+		}), {concurrency});
 	})();
 
 	promise.on = (...arguments_) => {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,6 +23,10 @@ expectType<Promise<string[]> & ProgressEmitter>(
 expectType<Promise<string[]> & ProgressEmitter>(
 	cpy('foo.js', 'destination', {overwrite: false})
 );
+expectType<Promise<string[]> & ProgressEmitter>(
+	cpy('foo.js', 'destination', {concurrency: 2})
+);
+
 
 expectType<Promise<string[]>>(
 	cpy('foo.js', 'destination').on('progress', progress => {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"arrify": "^2.0.1",
 		"cp-file": "^7.0.0",
 		"globby": "^9.2.0",
-		"nested-error-stacks": "^2.1.0"
+		"nested-error-stacks": "^2.1.0",
+		"p-all": "^2.1.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,12 @@ Type: `string | Function`
 
 Filename or function returning a filename used to rename every file in `source`.
 
+##### concurrency
+
+Type: `number`
+
+Number of files being copied concurrently.
+
 ```js
 const cpy = require('cpy');
 

--- a/readme.md
+++ b/readme.md
@@ -84,12 +84,6 @@ Type: `string | Function`
 
 Filename or function returning a filename used to rename every file in `source`.
 
-##### concurrency
-
-Type: `number`
-
-Number of files being copied concurrently.
-
 ```js
 const cpy = require('cpy');
 
@@ -99,6 +93,12 @@ const cpy = require('cpy');
 	});
 })();
 ```
+
+##### concurrency
+
+Type: `number`
+Default: `(os.cpus().length || 1) * 2`;
+Number of files being copied concurrently.
 
 
 ## Progress reporting

--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,9 @@ const cpy = require('cpy');
 
 ##### concurrency
 
-Type: `number`
-Default: `(os.cpus().length || 1) * 2`;
+Type: `number`<br>
+Default: `(os.cpus().length || 1) * 2`
+
 Number of files being copied concurrently.
 
 

--- a/test.js
+++ b/test.js
@@ -49,6 +49,11 @@ test('copy array of files', async t => {
 	t.is(read('package.json'), read(t.context.tmp, 'package.json'));
 });
 
+test('throws on invalid concurrency value', async t => {
+	await t.throwsAsync(cpy(['license', 'package.json'], t.context.tmp, {concurrency: -2}));
+	await t.throwsAsync(cpy(['license', 'package.json'], t.context.tmp, {concurrency: 'foo'}));
+});
+
 test('cwd', async t => {
 	fs.mkdirSync(t.context.tmp);
 	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));


### PR DESCRIPTION
Fixes #34.

Switches Promise.All for p-all, and adds concurrency option with suggested default value.