### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const preprocessDestinationPath = (source, destination, options) => {
 };
 
 module.exports = (source, destination, {
-	concurrency = (os.cpus().lengh || 1) * 2,
+	concurrency = (os.cpus().length || 1) * 2,
 	...options
 } = {}) => {
 	const progressEmitter = new EventEmitter();


### PR DESCRIPTION
The concurrency is not working coz of a typo `lengh` instead of `length`. This PR fixes the typo.