### PR TITLE
Fix empty check

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = (source, destination, {
 
 		const sourcePaths = source.filter(value => !isGlob(value));
 
-		if (files.length === 0 || (sourcePaths.length > 0 && !sourcePaths.every(value => files.includes(value)))) {
+		if (files.length === 0 && (sourcePaths.length > 0 && !sourcePaths.every(value => files.includes(value)))) {
 			throw new CpyError(`Cannot copy \`${source}\`: the file doesn't exist`);
 		}
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = (source, destination, {
 
 		const sourcePaths = source.filter(value => !isGlob(value));
 
-		if (files.length === 0 && (sourcePaths.length > 0 && !sourcePaths.every(value => files.includes(value)))) {
+		if (sourcePaths.length > 0 && (files.length === 0 || !sourcePaths.every(value => files.includes(value)))) {
 			throw new CpyError(`Cannot copy \`${source}\`: the file doesn't exist`);
 		}
 

--- a/test.js
+++ b/test.js
@@ -159,7 +159,7 @@ test('throws on multiple non-existing files', async t => {
 test('does not throw when not matching any file on glob pattern', async t => {
 	fs.mkdirSync(t.context.tmp);
 
-	await t.notThrowsAsync(cpy(['*.js'], t.context.tmp));
+	await t.notThrowsAsync(cpy(['*.nonexistent'], t.context.tmp));
 });
 
 test('throws on mixed path and glob if path does not exist', async t => {


### PR DESCRIPTION
This is a follow-up to #50. The check and the test to not throw when globs were included was wrong, because the glob provided actually _did_ match files.