### PR TITLE
Fix readme example

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ declare namespace cpy {
 
 		(async () => {
 			await cpy('foo', 'destination', {
-				filter: file => file.extension !== '.nocopy'
+				filter: file => file.extension !== 'nocopy'
 			});
 		})();
 		```

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ const cpy = require('cpy');
 
 (async () => {
 	await cpy('foo', 'destination', {
-		filter: file => file.extension !== '.nocopy'
+		filter: file => file.extension !== 'nocopy'
 	});
 })();
 ```


### PR DESCRIPTION
Since the extension gets the `.` trimmed, updated the example to match