### PR TITLE
Upgrade to globby 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cpy",
-	"version": "8.1.2",
+	"version": "9.0.0",
 	"description": "Copy files",
 	"license": "MIT",
 	"repository": "sindresorhus/cpy",
@@ -11,7 +11,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -45,7 +45,7 @@
 	"dependencies": {
 		"arrify": "^2.0.1",
 		"cp-file": "^7.0.0",
-		"globby": "^9.2.0",
+		"globby": "^11.0.3",
 		"has-glob": "^1.0.0",
 		"junk": "^3.1.0",
 		"nested-error-stacks": "^2.1.0",


### PR DESCRIPTION
globby 9.2 depends on fast-glob 2, which itself depends on an old version of `glob-parent` vulnerable to ReDoS attacks.
globby 11 depends on fast-glob 3, which uses the latest `glob-parent` that has been patched.

This requires a major version bump for 2 reasons:
- globby 11 dropped support for node <10, so this PR needs to drop it for cpy too
- cpy exposes the globby options directly, and so inherits the globby BC breaks.