### PR TITLE
update globby to version ^11.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	"dependencies": {
 		"arrify": "^2.0.1",
 		"cp-file": "^7.0.0",
-		"globby": "^9.2.0",
+		"globby": "^11.0.3",
 		"has-glob": "^1.0.0",
 		"junk": "^3.1.0",
 		"nested-error-stacks": "^2.1.0",


### PR DESCRIPTION
By using the latest version of globby, we can get rid of the security vulnerability related to glob-parent.

Seeing some test failures with these latest updates.

@sindresorhus Would you be able to help?