### PR TITLE
Fix recursive bugs

### DIFF
--- a/glob-pattern.js
+++ b/glob-pattern.js
@@ -14,6 +14,7 @@ export default class GlobPattern {
 		this.originalPath = pattern;
 		this.destination = destination;
 		this.options = options;
+		this.isDirectory = false;
 
 		if (
 			!isDynamicPattern(pattern)
@@ -21,6 +22,7 @@ export default class GlobPattern {
 				&& fs.lstatSync(pattern).isDirectory()
 		) {
 			this.path = [pattern, '**'].join('/');
+			this.isDirectory = true;
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,10 @@ const preprocessDestinationPath = ({entry, destination, options}) => {
 		return path.join(destination, entry.name);
 	}
 
+	if (path.isAbsolute(entry.path) && entry.pattern.isDirectory) {
+		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
+	}
+
 	return path.join(options.cwd, destination, path.relative(options.cwd, entry.path));
 };
 

--- a/index.js
+++ b/index.js
@@ -101,11 +101,11 @@ const preprocessDestinationPath = ({entry, destination, options}) => {
 		return path.join(destination, entry.name);
 	}
 
-	if (path.isAbsolute(entry.path) && entry.pattern.isDirectory) {
+	if (entry.pattern.isDirectory && path.relative(options.cwd, entry.path).startsWith('..')) {
 		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
 	}
 
-	if (path.isAbsolute(entry.path) && !entry.pattern.isDirectory) {
+	if (!entry.pattern.isDirectory && entry.path === entry.relativePath) {
 		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
 	}
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ const preprocessDestinationPath = ({entry, destination, options}) => {
 		return path.join(destination, entry.name);
 	}
 
+	// TODO: This check will not work correctly if `options.cwd` and `entry.path` are on different partitions on Windows, see: https://github.com/sindresorhus/import-local/pull/12
 	if (entry.pattern.isDirectory && path.relative(options.cwd, entry.path).startsWith('..')) {
 		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
 	}
@@ -163,6 +164,7 @@ export default function cpy(
 		let entries = [];
 		let completedFiles = 0;
 		let completedSize = 0;
+
 		/**
 		@type {GlobPattern[]}
 		*/

--- a/index.js
+++ b/index.js
@@ -196,7 +196,6 @@ export default function cpy(
 			];
 		}
 
-
 		if (options.filter !== undefined) {
 			entries = await pFilter(entries, options.filter, {concurrency: 1024});
 		}

--- a/index.js
+++ b/index.js
@@ -105,6 +105,10 @@ const preprocessDestinationPath = ({entry, destination, options}) => {
 		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
 	}
 
+	if (path.isAbsolute(entry.path) && !entry.pattern.isDirectory) {
+		return path.join(options.cwd, destination, path.basename(entry.pattern.originalPath), path.relative(entry.pattern.originalPath, entry.path));
+	}
+
 	return path.join(options.cwd, destination, path.relative(options.cwd, entry.path));
 };
 

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ class Entry {
 }
 
 /**
- * Expand patterns like:
- * "node_modules/{globby,micromatch}" into ["node_modules/globby", "node_modules/micromatch"]
+Expand patterns like `'node_modules/{globby,micromatch}'` into `['node_modules/globby', 'node_modules/micromatch']`.
+
 @param {string[]} patterns
 @returns {string[]}
 */

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"cp-file": "^9.1.0",
 		"globby": "^12.0.0",
 		"junk": "^3.1.0",
+		"micromatch": "^4.0.4",
 		"nested-error-stacks": "^2.1.0",
 		"p-filter": "^2.1.0",
 		"p-map": "^5.0.0"


### PR DESCRIPTION
This PR fixes 5 bugs:
- fixes #91
- fixes #73
- absolute directory source paths not working
- absolute file source paths not working
- negative patterns not working

This issue can be closed too:
- closes #30 


This PR completes my work on recursive feature

I'm also attaching a small migration guide bellow.

Can I get `hacktoberfest-accepted` label on this?

---

# Breaking changes & examples

## Recursive by default

- `parents` option was removed 
- to get flat list of files use `flat: true` option

Example directory structure:
```
- .github/workflows/main.yml
- .github/funding.yml
```


Command: `cpy('.github/**', 'dest')`

Old output:
```
- dest/funding.yml
- dest/main.yml
```
New output: 
```
- dest/workflows/main.yml
- dest/main.yml
```

## Recreate old `parents: true`

Example directory structure:
```
- .github/workflows/main.yml
- .github/funding.yml
```

Old:
`cpy('.github/**', 'dest', {parents: true})`

New:
`cpy('.github', 'dest')`

Output:
```
- dest/.github/workglows/main.yml
- dest/.github/funding.yml
```

## Recreate old `parents: false`
Example directory structure:
```
- .github/workflows/main.yml
- .github/funding.yml
```

Old:
`cpy('.github/**', 'dest', {parents: false})`

New:
`cpy('.github', 'dest', {flat: true})`

Output:
```
- dest/main.yml
- dest/funding.yml
```

## Copy all package.json and preserve folder structure

Old: 
`cpy('node_modules/**/package.json', 'dest', {parents: true})`

Old output:
![](https://i.imgur.com/sHOe35T.png)

New: 
`cpy('node_modules/**/package.json', 'dest')`

New output:
![](https://i.imgur.com/pYJEK2T.png)

> Ignore colors, those are git changes