### PR TITLE
Fix type to match implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ export type ProgressEmitter = {
 };
 
 export type CopyStatus = {
-	written: number;
+	writtenBytes: number;
 	percent: number;
 };
 


### PR DESCRIPTION
In implementation, `CopyStatus` has a `writtenBytes` property instead of  a `written` property. 

e.g.
https://github.com/sindresorhus/cpy/blob/7d6e8be9aa1cb8b993084512cb9ca4a48e1f21d3/index.js#L217-L220

So, I fixed type to match implementation.
