### PR TITLE
fix: fallback to `os.cpus` when `os.availableParallelism` missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const renameFile = (source, rename) => {
 export default function cpy(
 	source,
 	destination,
-	{concurrency = os.availableParallelism(), ...options} = {},
+	{concurrency = os.availableParallelism?.() ?? os.cpus().length, ...options} = {},
 ) {
 	const copyStatus = new Map();
 


### PR DESCRIPTION
I am using Node v18.12.0  and `os.availableParallelism` is not available